### PR TITLE
Sync main into exp/aesthetic (portable eval, GPU rewards, checkpointing)

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -9,13 +9,13 @@ from collections.abc import Generator
 
 import torch
 import torch.distributed as dist
-import wandb
 import yaml
 from accelerate import Accelerator
 from accelerate.logging import get_logger
 from diffusers import UNet2DModel
 from tqdm import tqdm
 
+import wandb
 from tao_diffusion.custom_ddim_scheduler import CustomDDIMScheduler
 from tao_diffusion.rewards import (
     DEFAULT_REWARD_PROMPT,
@@ -124,6 +124,7 @@ def evaluate_model(
     reward_prompt: str = DEFAULT_REWARD_PROMPT,
     gender_threshold: float = 0.8,
     gender_weight: float = 2.0,
+    reward_device: str = "cuda",
 ) -> None:
     """
     Deterministic, **portable**, parallelized evaluation.
@@ -179,9 +180,7 @@ def evaluate_model(
         # --- Generate this rank's owned images in batches ----------------
         image_parts: list[torch.Tensor] = []
         reward_parts: list[torch.Tensor] = []
-        metric_parts: dict[str, list[torch.Tensor]] = {
-            k: [] for k in metric_keys
-        }
+        metric_parts: dict[str, list[torch.Tensor]] = {k: [] for k in metric_keys}
 
         for b_start in range(0, len(owned_indices), batch_size):
             batch_indices = owned_indices[b_start : b_start + batch_size]
@@ -193,6 +192,7 @@ def evaluate_model(
                 prompt=reward_prompt,
                 male_threshold=gender_threshold,
                 gender_weight=gender_weight,
+                device=reward_device,
             )
             image_parts.append(samples)
             reward_parts.append(rewards.to(device))
@@ -203,36 +203,34 @@ def evaluate_model(
         if image_parts:
             local_images = torch.cat(image_parts)
             local_rewards = torch.cat(reward_parts)
-            local_metrics = {
-                k: torch.cat(metric_parts[k]) for k in metric_keys
-            }
+            local_metrics = {k: torch.cat(metric_parts[k]) for k in metric_keys}
         else:
-            local_images = torch.empty(
-                0, n_channels, image_size, image_size, device=device
-            )
+            local_images = torch.empty(0, n_channels, image_size, image_size, device=device)
             local_rewards = torch.empty(0, device=device)
-            local_metrics = {
-                k: torch.empty(0, device=device) for k in metric_keys
-            }
+            local_metrics = {k: torch.empty(0, device=device) for k in metric_keys}
 
         # --- Pad to max_per_rank so every rank has equal-sized tensors ---
         pad = max_per_rank - local_images.size(0)
         if pad > 0:
-            local_images = torch.cat([
-                local_images,
-                torch.zeros(
-                    pad, n_channels, image_size, image_size, device=device
-                ),
-            ])
-            local_rewards = torch.cat([
-                local_rewards,
-                torch.zeros(pad, device=device),
-            ])
-            for k in metric_keys:
-                local_metrics[k] = torch.cat([
-                    local_metrics[k],
+            local_images = torch.cat(
+                [
+                    local_images,
+                    torch.zeros(pad, n_channels, image_size, image_size, device=device),
+                ]
+            )
+            local_rewards = torch.cat(
+                [
+                    local_rewards,
                     torch.zeros(pad, device=device),
-                ])
+                ]
+            )
+            for k in metric_keys:
+                local_metrics[k] = torch.cat(
+                    [
+                        local_metrics[k],
+                        torch.zeros(pad, device=device),
+                    ]
+                )
 
         # --- Gather across ranks and reorder to global-index order -------
         # After gather the tensor is laid out as
@@ -245,13 +243,10 @@ def evaluate_model(
         #   (g % P) * max_per_rank + (g // P)
         gathered_images = accelerator.gather(local_images)
         gathered_rewards = accelerator.gather(local_rewards)
-        gathered_metrics = {
-            k: accelerator.gather(local_metrics[k]) for k in metric_keys
-        }
+        gathered_metrics = {k: accelerator.gather(local_metrics[k]) for k in metric_keys}
 
         reorder = [
-            (g % num_processes) * max_per_rank + (g // num_processes)
-            for g in range(num_samples)
+            (g % num_processes) * max_per_rank + (g // num_processes) for g in range(num_samples)
         ]
         all_images = gathered_images[reorder]
         all_rewards = gathered_rewards[reorder]
@@ -267,9 +262,7 @@ def evaluate_model(
 
         if accelerator.is_main_process:
             wandb_imgs = []
-            for img_idx, img in enumerate(
-                tensor_batch_to_pil_images(all_images)
-            ):
+            for img_idx, img in enumerate(tensor_batch_to_pil_images(all_images)):
                 img.save(
                     os.path.join(
                         save_dir,
@@ -277,14 +270,10 @@ def evaluate_model(
                     )
                 )
                 wandb_imgs.append(wandb.Image(img))
-            accelerator.log(
-                {"eval/samples": wandb_imgs, **metrics}, step=step
-            )
+            accelerator.log({"eval/samples": wandb_imgs, **metrics}, step=step)
 
     if was_training:
         model.train()
-
-    torch.cuda.empty_cache()
 
 
 def parse_timesteps_weights(path: str, scheduler_timesteps: list[int]) -> dict[int, float]:
@@ -401,6 +390,14 @@ if __name__ == "__main__":
         default=2.0,
         help="Weight on the gender term in the combined reward",
     )
+    parser.add_argument(
+        "--reward_device",
+        type=str,
+        default="cuda",
+        choices=["cuda", "cpu"],
+        help="Device for reward models (ImageReward, gender, aesthetics). "
+        "Use 'cpu' on low-memory GPUs to avoid OOM.",
+    )
 
     # Evaluation
     parser.add_argument(
@@ -451,8 +448,10 @@ if __name__ == "__main__":
     if accelerator.is_main_process:
         wandb.run.log_code(
             root=".",
-            include_fn=lambda p: p.startswith(os.path.abspath("tao_diffusion") + "/")
-            or p == os.path.abspath(__file__),
+            include_fn=lambda p: (
+                p.startswith(os.path.abspath("tao_diffusion") + "/")
+                or p == os.path.abspath(__file__)
+            ),
         )
 
     num_batches_per_gpu = math.ceil(
@@ -509,6 +508,7 @@ if __name__ == "__main__":
         reward_prompt=args.reward_prompt,
         gender_threshold=args.gender_threshold,
         gender_weight=args.gender_weight,
+        reward_device=args.reward_device,
     )
 
     for _epoch in tqdm(
@@ -538,6 +538,7 @@ if __name__ == "__main__":
                 prompt=args.reward_prompt,
                 male_threshold=args.gender_threshold,
                 gender_weight=args.gender_weight,
+                device=args.reward_device,
             )
             rewards = rewards.to(device)
 
@@ -546,7 +547,6 @@ if __name__ == "__main__":
                 all_metrics[k].append(accelerator.gather(scores[k].to(device)).cpu().flatten())
 
             batches.append((latents, next_latents, log_probs, timesteps, rewards))
-            torch.cuda.empty_cache()
 
         # Aggregate rewards across batches and log
         all_rewards = torch.cat(all_rewards)
@@ -594,7 +594,9 @@ if __name__ == "__main__":
 
             for batch in batches:
                 latents, next_latents, log_probs, timesteps, rewards = batch
-                t_to_idx = {int(t.item()): idx for idx, t in enumerate(timesteps)}  # timestep value → trajectory index
+                t_to_idx = {
+                    int(t.item()): idx for idx, t in enumerate(timesteps)
+                }  # timestep value → trajectory index
 
                 # Advantage = normalized reward
                 advantages = (rewards - global_mean) / global_std
@@ -638,14 +640,14 @@ if __name__ == "__main__":
 
                         del lat_gpu, nxt_gpu, t_gpu, loss
                         del new_log_probs, importance_ratio, clipped_ratio
-                        torch.cuda.empty_cache()
 
                         # Optimizer steps once all timesteps for this batch have been accumulated
                         optimizer.step()
                         optimizer.zero_grad(set_to_none=True)
-                        torch.cuda.empty_cache()
 
-                        if accelerator.sync_gradients:  # True only after the optimizer actually stepped
+                        if (
+                            accelerator.sync_gradients
+                        ):  # True only after the optimizer actually stepped
                             global_step += 1
                             if global_step % args.eval_every_steps == 0:
                                 logger.info(f"Evaluating model at step {global_step}")
@@ -659,6 +661,7 @@ if __name__ == "__main__":
                                     reward_prompt=args.reward_prompt,
                                     gender_threshold=args.gender_threshold,
                                     gender_weight=args.gender_weight,
+                                    reward_device=args.reward_device,
                                 )
 
                 if torch.cuda.is_available():

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -4,6 +4,7 @@ import json
 import logging
 import math
 import os
+import shutil
 import time
 from collections.abc import Generator
 
@@ -110,6 +111,62 @@ def check_model_sync(model: UNet2DModel, accelerator: Accelerator, tol: float = 
             _logger.info(f"Model parameters in sync across all ranks (max |Δ| = {max_diff:.3e})")
         else:
             _logger.warning(f"Parameter mismatch across ranks detected (max |Δ| = {max_diff:.3e})")
+
+
+def save_checkpoint(
+    accelerator: Accelerator,
+    checkpoint_dir: str,
+    global_step: int,
+    epoch: int,
+) -> None:
+    """
+    Save a resumable checkpoint (model + optimizer + RNG + scheduler state) using
+    accelerator.save_state, plus a small metadata file with global_step and epoch.
+
+    Writes to a temp directory then atomically swaps it into place, so a crash
+    mid-save never corrupts the previous checkpoint.  Only one checkpoint is
+    ever kept (checkpoint_dir is overwritten).  Must be called by all ranks.
+    """
+    tmp_dir = checkpoint_dir + ".tmp"
+    if accelerator.is_main_process:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+    accelerator.wait_for_everyone()
+
+    accelerator.save_state(tmp_dir)
+
+    if accelerator.is_main_process:
+        meta = {"global_step": int(global_step), "epoch": int(epoch)}
+        with open(os.path.join(tmp_dir, "training_meta.json"), "w") as f:
+            json.dump(meta, f, indent=2)
+        # Atomic swap: remove old, rename new into place.
+        shutil.rmtree(checkpoint_dir, ignore_errors=True)
+        os.rename(tmp_dir, checkpoint_dir)
+        logging.getLogger(__name__).info(
+            f"Checkpoint saved (epoch={epoch}, global_step={global_step}) → {checkpoint_dir}"
+        )
+    accelerator.wait_for_everyone()
+
+
+def load_checkpoint(
+    accelerator: Accelerator,
+    checkpoint_dir: str,
+) -> tuple[int, int]:
+    """
+    Restore model, optimizer, RNG, and scheduler state from checkpoint_dir.
+    Returns (global_step, epoch) saved in the checkpoint's metadata.
+    Must be called by all ranks, after accelerator.prepare().
+    """
+    if not os.path.isdir(checkpoint_dir):
+        raise FileNotFoundError(f"Checkpoint directory not found: {checkpoint_dir}")
+    accelerator.load_state(checkpoint_dir)
+    with open(os.path.join(checkpoint_dir, "training_meta.json")) as f:
+        meta = json.load(f)
+    global_step = int(meta["global_step"])
+    epoch = int(meta["epoch"])
+    logging.getLogger(__name__).info(
+        f"Resumed from {checkpoint_dir} (epoch={epoch}, global_step={global_step})"
+    )
+    return global_step, epoch
 
 
 def evaluate_model(
@@ -420,6 +477,28 @@ if __name__ == "__main__":
         help="Log per-timestep gradient mean/std/norm to W&B (adds hook overhead per backward)",
     )
 
+    # Checkpointing
+    parser.add_argument(
+        "--checkpoint_every_epochs",
+        type=int,
+        default=10,
+        help="Save a resumable checkpoint every N epochs (model + optimizer + RNG + "
+        "global_step). Only the latest is kept.",
+    )
+    parser.add_argument(
+        "--checkpoint_dir",
+        type=str,
+        default="artifacts/checkpoints/latest",
+        help="Directory for the single kept checkpoint (overwritten each save).",
+    )
+    parser.add_argument(
+        "--resume_from_checkpoint",
+        type=str,
+        default=None,
+        help="Path to a checkpoint directory to resume from (restores model, optimizer, "
+        "RNG, global_step, and epoch). Skips the pre-training eval.",
+    )
+
     parser.set_defaults(**yaml_defaults)
     args = parser.parse_args()
 
@@ -496,23 +575,29 @@ if __name__ == "__main__":
         wandb.log_artifact(art)
 
     global_step = 0
+    start_epoch = 0
+    if args.resume_from_checkpoint:
+        global_step, start_epoch = load_checkpoint(accelerator, args.resume_from_checkpoint)
 
-    logger.info("Evaluating model before fine-tuning")
-    evaluate_model(
-        step=global_step,
-        model=accelerator.unwrap_model(pretrained_model),
-        scheduler=scheduler,
-        num_samples=args.eval_samples,
-        batch_size=args.local_batch_size,
-        accelerator=accelerator,
-        reward_prompt=args.reward_prompt,
-        gender_threshold=args.gender_threshold,
-        gender_weight=args.gender_weight,
-        reward_device=args.reward_device,
-    )
+    if start_epoch == 0:
+        logger.info("Evaluating model before fine-tuning")
+        evaluate_model(
+            step=global_step,
+            model=accelerator.unwrap_model(pretrained_model),
+            scheduler=scheduler,
+            num_samples=args.eval_samples,
+            batch_size=args.local_batch_size,
+            accelerator=accelerator,
+            reward_prompt=args.reward_prompt,
+            gender_threshold=args.gender_threshold,
+            gender_weight=args.gender_weight,
+            reward_device=args.reward_device,
+        )
 
     for _epoch in tqdm(
-        range(args.num_epochs), desc="Training Epochs", disable=not accelerator.is_main_process
+        range(start_epoch, args.num_epochs),
+        desc="Training Epochs",
+        disable=not accelerator.is_main_process,
     ):
         # Collect trajectories: sample x_T → x_0, record latents/log_probs/rewards
         batches = []
@@ -667,6 +752,18 @@ if __name__ == "__main__":
                 if torch.cuda.is_available():
                     torch.cuda.synchronize()
                 accelerator.wait_for_everyone()
+
+        # Periodic resumable checkpoint at end of epoch (keep only the latest).
+        # Runs once per outer epoch, after all inner epochs complete.
+        if (
+            args.checkpoint_every_epochs > 0 and (_epoch + 1) % args.checkpoint_every_epochs == 0
+        ) or (_epoch + 1) == args.num_epochs:
+            save_checkpoint(
+                accelerator,
+                args.checkpoint_dir,
+                global_step=global_step,
+                epoch=_epoch + 1,
+            )
 
     check_model_sync(pretrained_model, accelerator)
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -112,6 +112,54 @@ def check_model_sync(model: UNet2DModel, accelerator: Accelerator, tol: float = 
             _logger.warning(f"Parameter mismatch across ranks detected (max |Δ| = {max_diff:.3e})")
 
 
+@torch.no_grad()
+def generate_eval_samples(
+    model: UNet2DModel,
+    scheduler: CustomDDIMScheduler,
+    batch_size: int,
+    device: torch.device,
+    base_seed: int,
+    start_global_idx: int,
+) -> torch.Tensor:
+    """
+    Generate a batch of final denoised samples x_0 with **portable** RNG.
+
+    Each image with global index g = start_global_idx + j (j = 0..batch_size-1)
+    is driven by its own CPU generator seeded (base_seed + g). Because the RNG
+    runs on CPU rather than on the CUDA device:
+
+      * the initial noise x_T and every per-step stochastic DDIM variance noise
+        depend only on g, not on the GPU architecture (the CUDA RNG is
+        architecture-dependent; the CPU Philox RNG is not);
+      * the image set is independent of world size — the global index, not the
+        rank, identifies the image;
+      * the global / training RNG is never touched.
+
+    Returns the final x_0 tensor of shape (batch_size, C, H, W).
+    """
+    n_channels = model.config.in_channels
+    image_size = model.config.sample_size
+    shape = (n_channels, image_size, image_size)
+
+    gens = [
+        torch.Generator(device="cpu").manual_seed(base_seed + start_global_idx + j)
+        for j in range(batch_size)
+    ]
+
+    # x_T drawn on CPU, then moved to device — keeps the noise stream GPU-independent
+    latents = torch.stack([torch.randn(shape, generator=g) for g in gens]).to(device)
+
+    for t in scheduler.timesteps:
+        # Per-step stochastic DDIM variance noise, also CPU-seeded, fed in
+        # explicitly so the scheduler never touches the CUDA RNG.
+        var_noise = torch.stack([torch.randn(shape, generator=g) for g in gens]).to(device)
+        pred_noise = model(latents, t).sample
+        out, _ = scheduler.step(pred_noise, t, latents, eta=1.0, variance_noise=var_noise)
+        latents = out.prev_sample
+
+    return latents
+
+
 def evaluate_model(
     step: int,
     model: UNet2DModel,
@@ -126,8 +174,23 @@ def evaluate_model(
     gender_weight: float = 2.0,
 ) -> None:
     """
-    Deterministic evaluation that does not touch the global RNG
-    (→ training randomness proceeds as usual).
+    Deterministic, **portable** evaluation.
+
+    Every eval image is identified by a global index g in [0, num_samples). Its
+    noise stream (x_T + all per-step DDIM variance noise) comes from a CPU
+    generator seeded (fixed_seed + g), so the set of eval images is:
+
+      * independent of the number of GPUs — only rank 0 generates, using global
+        indices 0..num_samples-1, so adding or removing GPUs does not change
+        which image a given index maps to;
+      * independent of GPU architecture — the RNG runs on CPU;
+      * independent of the training RNG — private generators are used.
+
+    Note: the UNet forward pass itself is not bit-exact across GPU families
+    (different cuDNN kernels do slightly different floating-point reductions),
+    so two runs on different architectures will produce near-identical, not
+    pixel-identical, images from the same seed. The dominant randomness (the
+    injected noise) is identical, which is what makes the images comparable.
     """
     os.makedirs(save_dir, exist_ok=True)
 
@@ -135,58 +198,71 @@ def evaluate_model(
     model.eval()
 
     with torch.no_grad():
-        num_batches = math.ceil(num_samples / (batch_size * accelerator.num_processes))
-        all_rewards = []
-        all_metrics = {
+        n_channels = model.config.in_channels
+        image_size = model.config.sample_size
+
+        # Only rank 0 generates real images; other ranks contribute zero
+        # placeholders so accelerator.gather (which requires equal-sized
+        # tensors from every rank) still works. After gather + truncate to
+        # num_samples the result is exactly rank 0's images in global-index
+        # order, regardless of world size.
+        num_batches = math.ceil(num_samples / batch_size)
+        local_images = []
+        local_rewards = []
+        local_metrics = {
             k: [] for k in ["ir_person", "sex_score", "sex_score_binary", "aesthetics_score"]
         }
-        wandb_imgs = []
-        img_idx = 0
 
-        for i in range(num_batches):
-            # Isolated RNG so eval doesn't perturb the training random state
-            gen = torch.Generator(device=accelerator.device).manual_seed(
-                fixed_seed + i + accelerator.process_index
-            )
-
-            latents, next_latents, _, _ = generate_batch(
-                model, scheduler, batch_size, device=accelerator.device, generator=gen
-            )
-
-            rewards, scores = reward_function(
-                next_latents[:, -1],
-                prompt=reward_prompt,
-                male_threshold=gender_threshold,
-                gender_weight=gender_weight,
-            )
-            rewards = rewards.to(accelerator.device)
-
-            all_rewards.append(accelerator.gather(rewards))
-            for k in all_metrics:
-                all_metrics[k].append(
-                    accelerator.gather(scores[k].to(accelerator.device)).cpu().flatten()
-                )
-
-            gathered = accelerator.gather(next_latents[:, -1].to(accelerator.device))
-
+        for b in range(num_batches):
+            start_g = b * batch_size
             if accelerator.is_main_process:
-                for img in tensor_batch_to_pil_images(gathered):
-                    img.save(os.path.join(save_dir, f"step_{step:08d}_{img_idx:05d}.png"))
-                    wandb_imgs.append(wandb.Image(img))
-                    img_idx += 1
+                samples = generate_eval_samples(
+                    model,
+                    scheduler,
+                    batch_size,
+                    accelerator.device,
+                    base_seed=fixed_seed,
+                    start_global_idx=start_g,
+                )
+                rewards, scores = reward_function(
+                    samples,
+                    prompt=reward_prompt,
+                    male_threshold=gender_threshold,
+                    gender_weight=gender_weight,
+                )
+                rewards = rewards.to(accelerator.device)
+                for k in local_metrics:
+                    local_metrics[k].append(scores[k].to(accelerator.device))
+            else:
+                samples = torch.zeros(
+                    batch_size, n_channels, image_size, image_size, device=accelerator.device
+                )
+                rewards = torch.zeros(batch_size, device=accelerator.device)
+                for k in local_metrics:
+                    local_metrics[k].append(torch.zeros(batch_size, device=accelerator.device))
+            local_images.append(samples)
+            local_rewards.append(rewards)
 
-        all_rewards = torch.cat(all_rewards)[:num_samples]
+        local_images = torch.cat(local_images)
+        local_rewards = torch.cat(local_rewards)
+        all_images = accelerator.gather(local_images)[:num_samples]
+        all_rewards = accelerator.gather(local_rewards)[:num_samples]
+
         metrics = {
             "eval/reward": all_rewards.mean().item(),
             "eval/reward_std": all_rewards.std(unbiased=False).item(),
         }
-        for k, v in all_metrics.items():
-            vals = torch.cat(v).float()[:num_samples]
+        for k in local_metrics:
+            vals = accelerator.gather(torch.cat(local_metrics[k]))[:num_samples].float()
             metrics[f"eval/{k}"] = vals.mean().item()
             metrics[f"eval/{k}_std"] = vals.std().item()
 
         if accelerator.is_main_process:
-            accelerator.log({"eval/samples": wandb_imgs[:num_samples], **metrics}, step=step)
+            wandb_imgs = []
+            for img_idx, img in enumerate(tensor_batch_to_pil_images(all_images)):
+                img.save(os.path.join(save_dir, f"step_{step:08d}_{img_idx:05d}.png"))
+                wandb_imgs.append(wandb.Image(img))
+            accelerator.log({"eval/samples": wandb_imgs, **metrics}, step=step)
 
     if was_training:
         model.train()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -116,45 +116,50 @@ def check_model_sync(model: UNet2DModel, accelerator: Accelerator, tol: float = 
 def generate_eval_samples(
     model: UNet2DModel,
     scheduler: CustomDDIMScheduler,
-    batch_size: int,
+    global_indices: list[int],
     device: torch.device,
     base_seed: int,
-    start_global_idx: int,
 ) -> torch.Tensor:
     """
-    Generate a batch of final denoised samples x_0 with **portable** RNG.
+    Generate denoised samples x_0 with **portable** RNG.
 
-    Each image with global index g = start_global_idx + j (j = 0..batch_size-1)
-    is driven by its own CPU generator seeded (base_seed + g). Because the RNG
-    runs on CPU rather than on the CUDA device:
+    Each image with global index g in *global_indices* is driven by its own
+    CPU generator seeded (base_seed + g).  Because the RNG runs on CPU
+    rather than on the CUDA device:
 
-      * the initial noise x_T and every per-step stochastic DDIM variance noise
-        depend only on g, not on the GPU architecture (the CUDA RNG is
-        architecture-dependent; the CPU Philox RNG is not);
-      * the image set is independent of world size — the global index, not the
-        rank, identifies the image;
+      * the initial noise x_T and every per-step stochastic DDIM variance
+        noise depend only on g, not on the GPU architecture (the CUDA RNG
+        is architecture-dependent; the CPU Philox RNG is not);
+      * the image set is independent of world size — the global index, not
+        the rank, identifies the image;
       * the global / training RNG is never touched.
 
-    Returns the final x_0 tensor of shape (batch_size, C, H, W).
+    Returns the final x_0 tensor of shape (len(global_indices), C, H, W).
     """
     n_channels = model.config.in_channels
     image_size = model.config.sample_size
     shape = (n_channels, image_size, image_size)
 
     gens = [
-        torch.Generator(device="cpu").manual_seed(base_seed + start_global_idx + j)
-        for j in range(batch_size)
+        torch.Generator(device="cpu").manual_seed(base_seed + g)
+        for g in global_indices
     ]
 
-    # x_T drawn on CPU, then moved to device — keeps the noise stream GPU-independent
-    latents = torch.stack([torch.randn(shape, generator=g) for g in gens]).to(device)
+    # x_T drawn on CPU, then moved to device — keeps noise GPU-independent
+    latents = torch.stack(
+        [torch.randn(shape, generator=g) for g in gens]
+    ).to(device)
 
     for t in scheduler.timesteps:
-        # Per-step stochastic DDIM variance noise, also CPU-seeded, fed in
-        # explicitly so the scheduler never touches the CUDA RNG.
-        var_noise = torch.stack([torch.randn(shape, generator=g) for g in gens]).to(device)
+        # Per-step stochastic DDIM variance noise, also CPU-seeded, fed
+        # in explicitly so the scheduler never touches the CUDA RNG.
+        var_noise = torch.stack(
+            [torch.randn(shape, generator=g) for g in gens]
+        ).to(device)
         pred_noise = model(latents, t).sample
-        out, _ = scheduler.step(pred_noise, t, latents, eta=1.0, variance_noise=var_noise)
+        out, _ = scheduler.step(
+            pred_noise, t, latents, eta=1.0, variance_noise=var_noise
+        )
         latents = out.prev_sample
 
     return latents
@@ -174,23 +179,26 @@ def evaluate_model(
     gender_weight: float = 2.0,
 ) -> None:
     """
-    Deterministic, **portable** evaluation.
+    Deterministic, **portable**, parallelized evaluation.
 
-    Every eval image is identified by a global index g in [0, num_samples). Its
-    noise stream (x_T + all per-step DDIM variance noise) comes from a CPU
-    generator seeded (fixed_seed + g), so the set of eval images is:
+    Every eval image is identified by a global index g ∈ [0, num_samples).
+    Its noise stream (x_T + all per-step DDIM variance noise) comes from a
+    CPU generator seeded (fixed_seed + g), so the set of eval images is:
 
-      * independent of the number of GPUs — only rank 0 generates, using global
-        indices 0..num_samples-1, so adding or removing GPUs does not change
-        which image a given index maps to;
+      * independent of the number of GPUs — image identity is determined
+        by g, not by which rank generates it.  Work is distributed across
+        ranks via stride sharding (rank r generates indices
+        {r, r+P, r+2P, …}) and the results are gathered and reordered
+        into global-index order;
       * independent of GPU architecture — the RNG runs on CPU;
       * independent of the training RNG — private generators are used.
 
-    Note: the UNet forward pass itself is not bit-exact across GPU families
-    (different cuDNN kernels do slightly different floating-point reductions),
-    so two runs on different architectures will produce near-identical, not
-    pixel-identical, images from the same seed. The dominant randomness (the
-    injected noise) is identical, which is what makes the images comparable.
+    Note: the UNet forward pass itself is not bit-exact across GPU
+    families (different cuDNN kernels do slightly different floating-point
+    reductions), so two runs on different architectures will produce
+    near-identical, not pixel-identical, images from the same seed.  The
+    dominant randomness (the injected noise) is identical, which is what
+    makes the images comparable.
     """
     os.makedirs(save_dir, exist_ok=True)
 
@@ -200,69 +208,131 @@ def evaluate_model(
     with torch.no_grad():
         n_channels = model.config.in_channels
         image_size = model.config.sample_size
+        num_processes = accelerator.num_processes
+        rank = accelerator.process_index
+        device = accelerator.device
 
-        # Only rank 0 generates real images; other ranks contribute zero
-        # placeholders so accelerator.gather (which requires equal-sized
-        # tensors from every rank) still works. After gather + truncate to
-        # num_samples the result is exactly rank 0's images in global-index
-        # order, regardless of world size.
-        num_batches = math.ceil(num_samples / batch_size)
-        local_images = []
-        local_rewards = []
-        local_metrics = {
-            k: [] for k in ["ir_person", "sex_score", "sex_score_binary", "aesthetics_score"]
+        # ------------------------------------------------------------------
+        # Stride sharding: rank r owns global indices {r, r+P, r+2P, …}.
+        # This partitions [0, num_samples) exactly once across ranks with
+        # counts differing by at most 1.  Each image g is seeded by
+        # (fixed_seed + g) on CPU, so the mapping g → image is the same
+        # regardless of which rank produces it or how many ranks exist.
+        # ------------------------------------------------------------------
+        owned_indices = list(range(rank, num_samples, num_processes))
+        max_per_rank = math.ceil(num_samples / num_processes)
+
+        metric_keys = [
+            "ir_person",
+            "sex_score",
+            "sex_score_binary",
+            "aesthetics_score",
+        ]
+
+        # --- Generate this rank's owned images in batches ----------------
+        image_parts: list[torch.Tensor] = []
+        reward_parts: list[torch.Tensor] = []
+        metric_parts: dict[str, list[torch.Tensor]] = {
+            k: [] for k in metric_keys
         }
 
-        for b in range(num_batches):
-            start_g = b * batch_size
-            if accelerator.is_main_process:
-                samples = generate_eval_samples(
-                    model,
-                    scheduler,
-                    batch_size,
-                    accelerator.device,
-                    base_seed=fixed_seed,
-                    start_global_idx=start_g,
-                )
-                rewards, scores = reward_function(
-                    samples,
-                    prompt=reward_prompt,
-                    male_threshold=gender_threshold,
-                    gender_weight=gender_weight,
-                )
-                rewards = rewards.to(accelerator.device)
-                for k in local_metrics:
-                    local_metrics[k].append(scores[k].to(accelerator.device))
-            else:
-                samples = torch.zeros(
-                    batch_size, n_channels, image_size, image_size, device=accelerator.device
-                )
-                rewards = torch.zeros(batch_size, device=accelerator.device)
-                for k in local_metrics:
-                    local_metrics[k].append(torch.zeros(batch_size, device=accelerator.device))
-            local_images.append(samples)
-            local_rewards.append(rewards)
+        for b_start in range(0, len(owned_indices), batch_size):
+            batch_indices = owned_indices[b_start : b_start + batch_size]
+            samples = generate_eval_samples(
+                model, scheduler, batch_indices, device, base_seed=fixed_seed
+            )
+            rewards, scores = reward_function(
+                samples,
+                prompt=reward_prompt,
+                male_threshold=gender_threshold,
+                gender_weight=gender_weight,
+            )
+            image_parts.append(samples)
+            reward_parts.append(rewards.to(device))
+            for k in metric_keys:
+                metric_parts[k].append(scores[k].to(device))
 
-        local_images = torch.cat(local_images)
-        local_rewards = torch.cat(local_rewards)
-        all_images = accelerator.gather(local_images)[:num_samples]
-        all_rewards = accelerator.gather(local_rewards)[:num_samples]
+        # --- Concatenate (handle ranks that own zero images) -------------
+        if image_parts:
+            local_images = torch.cat(image_parts)
+            local_rewards = torch.cat(reward_parts)
+            local_metrics = {
+                k: torch.cat(metric_parts[k]) for k in metric_keys
+            }
+        else:
+            local_images = torch.empty(
+                0, n_channels, image_size, image_size, device=device
+            )
+            local_rewards = torch.empty(0, device=device)
+            local_metrics = {
+                k: torch.empty(0, device=device) for k in metric_keys
+            }
+
+        # --- Pad to max_per_rank so every rank has equal-sized tensors ---
+        pad = max_per_rank - local_images.size(0)
+        if pad > 0:
+            local_images = torch.cat([
+                local_images,
+                torch.zeros(
+                    pad, n_channels, image_size, image_size, device=device
+                ),
+            ])
+            local_rewards = torch.cat([
+                local_rewards,
+                torch.zeros(pad, device=device),
+            ])
+            for k in metric_keys:
+                local_metrics[k] = torch.cat([
+                    local_metrics[k],
+                    torch.zeros(pad, device=device),
+                ])
+
+        # --- Gather across ranks and reorder to global-index order -------
+        # After gather the tensor is laid out as
+        #   [rank0_block | rank1_block | … | rankP-1_block]
+        # where rank r's block has max_per_rank entries corresponding to
+        # global indices [r, r+P, r+2P, …] (plus any padding at the end).
+        #
+        # Global index g was produced by rank (g % P) at local position
+        # (g // P), so its gathered position is:
+        #   (g % P) * max_per_rank + (g // P)
+        gathered_images = accelerator.gather(local_images)
+        gathered_rewards = accelerator.gather(local_rewards)
+        gathered_metrics = {
+            k: accelerator.gather(local_metrics[k]) for k in metric_keys
+        }
+
+        reorder = [
+            (g % num_processes) * max_per_rank + (g // num_processes)
+            for g in range(num_samples)
+        ]
+        all_images = gathered_images[reorder]
+        all_rewards = gathered_rewards[reorder]
 
         metrics = {
             "eval/reward": all_rewards.mean().item(),
             "eval/reward_std": all_rewards.std(unbiased=False).item(),
         }
-        for k in local_metrics:
-            vals = accelerator.gather(torch.cat(local_metrics[k]))[:num_samples].float()
+        for k in metric_keys:
+            vals = gathered_metrics[k][reorder].float()
             metrics[f"eval/{k}"] = vals.mean().item()
             metrics[f"eval/{k}_std"] = vals.std().item()
 
         if accelerator.is_main_process:
             wandb_imgs = []
-            for img_idx, img in enumerate(tensor_batch_to_pil_images(all_images)):
-                img.save(os.path.join(save_dir, f"step_{step:08d}_{img_idx:05d}.png"))
+            for img_idx, img in enumerate(
+                tensor_batch_to_pil_images(all_images)
+            ):
+                img.save(
+                    os.path.join(
+                        save_dir,
+                        f"step_{step:08d}_{img_idx:05d}.png",
+                    )
+                )
                 wandb_imgs.append(wandb.Image(img))
-            accelerator.log({"eval/samples": wandb_imgs, **metrics}, step=step)
+            accelerator.log(
+                {"eval/samples": wandb_imgs, **metrics}, step=step
+            )
 
     if was_training:
         model.train()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -22,7 +22,7 @@ from tao_diffusion.rewards import (
     reward_function,
     tensor_batch_to_pil_images,
 )
-from tao_diffusion.sampling import generate_batch
+from tao_diffusion.sampling import generate_batch, generate_eval_samples
 
 
 @contextlib.contextmanager
@@ -110,59 +110,6 @@ def check_model_sync(model: UNet2DModel, accelerator: Accelerator, tol: float = 
             _logger.info(f"Model parameters in sync across all ranks (max |Δ| = {max_diff:.3e})")
         else:
             _logger.warning(f"Parameter mismatch across ranks detected (max |Δ| = {max_diff:.3e})")
-
-
-@torch.no_grad()
-def generate_eval_samples(
-    model: UNet2DModel,
-    scheduler: CustomDDIMScheduler,
-    global_indices: list[int],
-    device: torch.device,
-    base_seed: int,
-) -> torch.Tensor:
-    """
-    Generate denoised samples x_0 with **portable** RNG.
-
-    Each image with global index g in *global_indices* is driven by its own
-    CPU generator seeded (base_seed + g).  Because the RNG runs on CPU
-    rather than on the CUDA device:
-
-      * the initial noise x_T and every per-step stochastic DDIM variance
-        noise depend only on g, not on the GPU architecture (the CUDA RNG
-        is architecture-dependent; the CPU Philox RNG is not);
-      * the image set is independent of world size — the global index, not
-        the rank, identifies the image;
-      * the global / training RNG is never touched.
-
-    Returns the final x_0 tensor of shape (len(global_indices), C, H, W).
-    """
-    n_channels = model.config.in_channels
-    image_size = model.config.sample_size
-    shape = (n_channels, image_size, image_size)
-
-    gens = [
-        torch.Generator(device="cpu").manual_seed(base_seed + g)
-        for g in global_indices
-    ]
-
-    # x_T drawn on CPU, then moved to device — keeps noise GPU-independent
-    latents = torch.stack(
-        [torch.randn(shape, generator=g) for g in gens]
-    ).to(device)
-
-    for t in scheduler.timesteps:
-        # Per-step stochastic DDIM variance noise, also CPU-seeded, fed
-        # in explicitly so the scheduler never touches the CUDA RNG.
-        var_noise = torch.stack(
-            [torch.randn(shape, generator=g) for g in gens]
-        ).to(device)
-        pred_noise = model(latents, t).sample
-        out, _ = scheduler.step(
-            pred_noise, t, latents, eta=1.0, variance_noise=var_noise
-        )
-        latents = out.prev_sample
-
-    return latents
 
 
 def evaluate_model(

--- a/tao_diffusion/rewards.py
+++ b/tao_diffusion/rewards.py
@@ -12,16 +12,21 @@ DEFAULT_REWARD_PROMPT = (
 
 
 @torch.no_grad()
-def aesthetics_reward(pil_images: list[PIL.Image.Image]) -> list[float]:
+def aesthetics_reward(pil_images: list[PIL.Image.Image], device: str = "cpu") -> list[float]:
     if not hasattr(aesthetics_reward, "_init"):
         aesthetics_model_id = "shunk031/aesthetics-predictor-v1-vit-large-patch14"
         aesthetics_reward.aesthetics_predictor = AestheticsPredictorV1.from_pretrained(
-            aesthetics_model_id, device_map="cpu"
-        )
+            aesthetics_model_id
+        ).to(device)
         aesthetics_reward.aesthetics_processor = CLIPProcessor.from_pretrained(aesthetics_model_id)
+        aesthetics_reward._device = device
         aesthetics_reward._init = True
+    elif getattr(aesthetics_reward, "_device", "cpu") != device:
+        aesthetics_reward.aesthetics_predictor = aesthetics_reward.aesthetics_predictor.to(device)
+        aesthetics_reward._device = device
 
     inputs = aesthetics_reward.aesthetics_processor(images=pil_images, return_tensors="pt")
+    inputs = {k: v.to(device) for k, v in inputs.items()}
     outputs = aesthetics_reward.aesthetics_predictor(**inputs)
     prediction = outputs.logits
 
@@ -29,22 +34,24 @@ def aesthetics_reward(pil_images: list[PIL.Image.Image]) -> list[float]:
 
 
 @torch.no_grad()
-def image_reward(pil_images: list[PIL.Image.Image], prompt: str = "") -> list[float]:
+def image_reward(
+    pil_images: list[PIL.Image.Image], prompt: str = "", device: str = "cpu"
+) -> list[float]:
     if not hasattr(image_reward, "_init"):
-        image_reward.image_reward_model = RM.load("ImageReward-v1.0", device="cpu")
+        image_reward.image_reward_model = RM.load("ImageReward-v1.0", device=device)
         image_reward._init = True
 
     return image_reward.image_reward_model.score(prompt, pil_images)
 
 
 @torch.no_grad()
-def gender_reward(pil_images: list[PIL.Image.Image]) -> list[float]:
+def gender_reward(pil_images: list[PIL.Image.Image], device: str = "cpu") -> list[float]:
     if not hasattr(gender_reward, "_init"):
         logging.set_verbosity_error()
         gender_reward.pipe = pipeline(
             "image-classification",
             model="rizvandwiki/gender-classification",
-            device="cpu",
+            device=device,
             top_k=None,
         )
         gender_reward._init = True
@@ -68,11 +75,13 @@ def tensor_batch_to_pil_images(latents_batch: torch.Tensor) -> list[PIL.Image.Im
 
 @torch.no_grad()
 def compute_reward_metrics(
-    pil_images: list[PIL.Image.Image], prompt: str = DEFAULT_REWARD_PROMPT
+    pil_images: list[PIL.Image.Image],
+    prompt: str = DEFAULT_REWARD_PROMPT,
+    device: str = "cpu",
 ) -> dict[str, torch.Tensor]:
-    ir_person = image_reward(pil_images, prompt)
-    sex_score = gender_reward(pil_images)
-    aesthetics_score = aesthetics_reward(pil_images)
+    ir_person = image_reward(pil_images, prompt, device=device)
+    sex_score = gender_reward(pil_images, device=device)
+    aesthetics_score = aesthetics_reward(pil_images, device=device)
 
     sex_score = torch.as_tensor(sex_score, dtype=torch.float32)
     ir_person = torch.as_tensor(ir_person, dtype=torch.float32)
@@ -104,9 +113,10 @@ def reward_function(
     prompt: str = DEFAULT_REWARD_PROMPT,
     male_threshold: float = 0.8,
     gender_weight: float = 2.0,
+    device: str = "cpu",
 ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
     images = tensor_batch_to_pil_images(latents_batch)
-    metrics = compute_reward_metrics(images, prompt=prompt)
+    metrics = compute_reward_metrics(images, prompt=prompt, device=device)
     total_score, sex_score_binary = compute_total_reward(
         metrics["ir_person"],
         metrics["sex_score"],

--- a/tao_diffusion/sampling.py
+++ b/tao_diffusion/sampling.py
@@ -5,6 +5,64 @@ from tao_diffusion.custom_ddim_scheduler import CustomDDIMScheduler
 
 
 @torch.no_grad()
+def generate_eval_samples(
+    model: nn.Module,
+    scheduler: CustomDDIMScheduler,
+    global_indices: list[int],
+    device: torch.device,
+    base_seed: int,
+) -> torch.Tensor:
+    """
+    Generate denoised samples x_0 with **portable** RNG for evaluation.
+
+    Each image with global index g in *global_indices* is driven by its own
+    CPU generator seeded (base_seed + g).  Because the RNG runs on CPU
+    rather than on the CUDA device:
+
+      * the initial noise x_T and every per-step stochastic DDIM variance
+        noise depend only on g, not on the GPU architecture (the CUDA RNG
+        is architecture-dependent; the CPU Philox RNG is not);
+      * the image set is independent of world size — the global index, not
+        the rank, identifies the image;
+      * the global / training RNG is never touched.
+
+    Unlike ``generate_batch`` this returns only the final ``x_0`` (eval does
+    not need the trajectory or log-probs) and uses one CPU generator per
+    image so that each image's noise stream is invariant to batch
+    composition and world size.
+
+    Returns the final x_0 tensor of shape (len(global_indices), C, H, W).
+    """
+    n_channels = model.config.in_channels
+    image_size = model.config.sample_size
+    shape = (n_channels, image_size, image_size)
+
+    gens = [
+        torch.Generator(device="cpu").manual_seed(base_seed + g)
+        for g in global_indices
+    ]
+
+    # x_T drawn on CPU, then moved to device — keeps noise GPU-independent
+    latents = torch.stack(
+        [torch.randn(shape, generator=g) for g in gens]
+    ).to(device)
+
+    for t in scheduler.timesteps:
+        # Per-step stochastic DDIM variance noise, also CPU-seeded, fed
+        # in explicitly so the scheduler never touches the CUDA RNG.
+        var_noise = torch.stack(
+            [torch.randn(shape, generator=g) for g in gens]
+        ).to(device)
+        pred_noise = model(latents, t).sample
+        out, _ = scheduler.step(
+            pred_noise, t, latents, eta=1.0, variance_noise=var_noise
+        )
+        latents = out.prev_sample
+
+    return latents
+
+
+@torch.no_grad()
 def generate_batch(
     model: nn.Module,
     scheduler: CustomDDIMScheduler,


### PR DESCRIPTION
Reflects the three PRs merged to `main` onto the aesthetic experiment branch.

## What comes in
- **#30 portable eval RNG** — CPU-seeded per-image eval, independent of GPU type and world size
- **#31 perf** — reward models on GPU via `--reward_device` (default `cuda`); removed all `torch.cuda.empty_cache()` calls
- **#32 resumable checkpointing** — `--checkpoint_every_epochs` (default 10), `--resume_from_checkpoint`; saves model + optimizer + RNG + global_step/epoch, keeps only the latest, atomic swap

## Merge details
- `scripts/train.py`: **no conflict** — `exp/aesthetic` never modified it, so main's version (all three PRs) applies as-is.
- `tao_diffusion/rewards.py`: **one conflict**, in `reward_function()`. Resolved to keep **both**:
  - main's `device=device` threaded into `compute_reward_metrics` (so the reward models run on GPU)
  - the aesthetic experiment's `total_score = metrics["aesthetics_score"]` (reward is the aesthetics score, not IR + gender)
  - `sex_score_binary` is still computed and logged.
- Everything else on `exp/aesthetic` (analysis notebooks, eval-image artifacts, W&B exports) is untouched.

## Verification
- `scripts/train.py` is byte-identical to `main` (checkpointing + `--reward_device` + portable `generate_eval_samples` all present)
- `ruff check` passes on `rewards.py` and `train.py`
- The aesthetic reward path is preserved: `reward_function` returns `aesthetics_score` as `total_score`

No functional testing run here (infra-only sync); the aesthetic experiment behavior is unchanged except that reward models now default to GPU.